### PR TITLE
Add Starsmith Oracles module for FoundryVTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A categorized collection of high-quality [Ironsworn](https://www.ironswornrpg.co
 * [Starforged Crew Sheet](https://jaderavens.itch.io/starforged-crew-sheet) - Interactive playkit for group/solo play in Google Sheets
 * [Starforged Sectors Discord Bot](https://github.com/Ferretsroq/Starforged-Sectors) - Display, create, and explore sectors in Discord
 * [Starforged Numbers Spreadsheet](https://www.dropbox.com/s/ge40xrazw0c9ng1/Starforged%20Public%20v2.5.numbers?dl=0) - Spreadsheet for Starforged solo play
+* [Starsmith Expanded Oracles Module for FoundryVTT](https://foundryvtt.com/packages/starsmith-expanded-oracles) - A FoundryVTT compendium of the Starsmith oracles for the Ironsworn: Starforged system
 * [TheOracle](https://github.com/XenotropicDev/TheOracle) - Discord bot for Ironsworn, with a focus on play-by-post games
 
 ## Resources


### PR DESCRIPTION
* Project name: Starsmith Oracles Module for FoundryVTT
* Project URL: https://foundryvtt.com/packages/starsmith-expanded-oracles
  
## Why it's awesome
A FoundryVTT compendium of the Starsmith oracles for the Ironsworn: Starforged system.

