### PR TITLE
Add Iron Vault plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A categorized collection of high-quality [Ironsworn](https://www.ironswornrpg.co
 * [Fusake Play Aid](https://docs.google.com/document/d/191sfXfcrxars0CXgLNN54eCoQRsuPmyd5Qe-IS5Vlhg/view) - Microsoft Excel play-aid for solo Ironsworn play
 * [Iron Fellowship](https://iron-fellowship.scottbenton.dev/) - Synced character sheet and campaign manager for Ironsworn
 * [Iron Journal](https://nboughton.uk/apps/ironsworn-campaign/) - Tools and references for running and journaling Ironsworn games
+* [Iron Vault](https://github.com/iron-vault-plugin/iron-vault/) - Ironsworn/Starforged plugin for [Obsidian](https://obsidian.md/)
 * [IronWriter](https://github.com/SHiLLySiT/IronWriter/blob/master/readme.md) - Writing tool for solo Ironsworn playthroughs
 * [Ironsmith Expanded Oracles Module for FoundryVTT](https://foundryvtt.com/packages/ironsmith-expanded-oracles) - A FoundryVTT compendium of the Ironsmith oracles for Ironsworn
 * [Ironsworn Character Creation Questions](https://www.drivethrurpg.com/product/392486/Ironsworn-Character-Creation-Questions) - Questions to help build NPC relationships


### PR DESCRIPTION
* Project name: Iron Vault
* Project URL: https://github.com/iron-vault-plugin/iron-vault/
  
## Why it's awesome

Brings a VTT-like experience for Ironsworn and Starforged (as well as Delve, Sundered Isles, and anything else in the Datasworn format) to the [Obsidian](https://obsidian.md) editor. Extensive documentation, including a Getting Started guide that walks players through using Iron Vault to go from the start of Starforged's campaign launch process through to making your first move.

(Disclosure: I am one of the authors, so obviously I think it's awesome.)